### PR TITLE
Update gh-actions & dependabot conf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+  assignees:
+    - "dalito"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
         - '3.12'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -48,8 +48,9 @@ jobs:
         python -m coverage run -p -m pytest
 
     - name: Upload coverage data
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
+        include-hidden-files: true
         name: coverage-data-${{ matrix.python-version }}
         path: .coverage.*
 
@@ -58,9 +59,9 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.12'
 
@@ -68,7 +69,7 @@ jobs:
         run: python -m pip install --upgrade coverage[toml]
 
       - name: Download data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -79,11 +80,11 @@ jobs:
           python -m coverage html --skip-empty
           echo '## Test Coverage Report' >> $GITHUB_STEP_SUMMARY
           python -m coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-          python -m coverage report --fail-under=94
+          python -m coverage report --fail-under=100
 
       - name: Upload HTML report
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
         with:
           name: html-report
           path: .htmlcov


### PR DESCRIPTION
Fix for breaking change in gh-action/upload-artifact 4.4 which excludes hidden files. Since the coverage data are hidden files the job fails after the update if hidden files are not explicitly allowed.