### PR TITLE
Setup tox & switch dependabot to grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# This configures updates via dependabot only for github actions.
+# All updates are grouped into a single PR.
 
 version: 2
 updates:
@@ -9,3 +9,9 @@ updates:
     interval: monthly
   assignees:
     - "dalito"
+  groups:
+    github-actions:
+      patterns:
+        - "*"
+
+# Ref: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FORCE_COLOR: "1"  # Make tool output pretty.
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PIP_PROGRESS_BAR: "off"
 
@@ -26,9 +25,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.10'
-        - '3.11'
         - '3.12'
+        - '3.13'
+        - '3.14'
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
-          python-version: 3.12
+          python-version: '3.14'
 
       - name: Install uv
         run: pipx install uv
@@ -63,9 +63,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
 
 # [1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-# Used actions: (updates managed by dependabot)
-# - https://github.com/actions/checkout
-# - https://github.com/actions/setup-python
-# - https://github.com/actions/upload-artifact
-# - https://github.com/actions/download-artifact
-# - https://github.com/pypa/gh-action-pypi-publish/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
 [project]
 # Storing project metadata in pyproject.toml https://peps.python.org/pep-0621/
 name = "cared-cli"
@@ -11,7 +15,7 @@ maintainers = [
 ]
 license = {text = "Apache 2.0"}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 keywords = ["CaReD", "RDM", "ELN", "LIMS"]
 # https://pypi.org/classifiers/
 classifiers = [
@@ -21,9 +25,9 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "click>=8.1.7",
@@ -51,10 +55,6 @@ dev = [
 
 [project.scripts]
 cared = "cared_cli._cli:app"
-
-[build-system]
-requires = ["hatchling", "hatch-vcs"]
-build-backend = "hatchling.build"
 
 [tool.hatch.metadata]
 # Hatch disallows direct references for dependencies by default.

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+requires = tox>=4.32
+env_list = clean, py{312,313,314}, report
+skip_missing_interpreters = true
+
+[testenv]
+# Use coverage run for proper parallel data file handling
+commands = coverage run -m pytest
+deps =
+    pytest
+    coverage
+depends =
+    py{312,313,314}: clean
+
+[testenv:report]
+deps = coverage
+skip_install = true
+depends = py{312,313,314}
+commands =
+    coverage combine
+    coverage report
+    coverage html
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase


### PR DESCRIPTION
This PR
* updates Python compatibility in `pyproject.toml` and CI/publishing workflows to support Python 3.12, 3.13, and 3.14; removed support for 3.10 and 3.11.
* adds a new `tox.ini` file to enable testing across Python 3.12, 3.13, and 3.14, including coverage reporting
* updates `.github/dependabot.yml` to group all GitHub Actions updates into a single PR/month
